### PR TITLE
feat(ReactSuspenseAndLazyLoading): Using `React.lazy` and `Suspense`

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,5 +1,6 @@
 import "./App.css";
-import PerformanceOptimizationUseMemoUseCallback from "./exercises/PerformanceOptimizationUseMemoUseCallback/PerformanceOptimizationUseMemoUseCallback";
+// import PerformanceOptimizationUseMemoUseCallback from "./exercises/PerformanceOptimizationUseMemoUseCallback/PerformanceOptimizationUseMemoUseCallback";
+import ReactSuspenseAndLazyLoading from "./exercises/ReactSuspenseAndLazyLoading/ReactSuspenseAndLazyLoading";
 // import FormsWithMultipleInputsAndValidation from "./exercises/FormsWithMultipleInputsAndValidation";
 // import ListsKeysMemoisation from "./exercises/ListsKeysMemoisation";
 // import DataFetchingWithUseEffect from "./exercises/DataFetchingWithUseEffect";
@@ -41,8 +42,12 @@ function App() {
         <CreatingCustomHook />
       </section> */}
 
-      <section>
+      {/* <section>
         <PerformanceOptimizationUseMemoUseCallback />
+      </section> */}
+
+      <section>
+        <ReactSuspenseAndLazyLoading />
       </section>
     </main>
   );

--- a/frontend/src/exercises/ReactSuspenseAndLazyLoading/ReactSuspenseAndLazyLoading.css
+++ b/frontend/src/exercises/ReactSuspenseAndLazyLoading/ReactSuspenseAndLazyLoading.css
@@ -1,0 +1,50 @@
+.l-suspense-lazy-loading-container {
+  display: grid;
+  place-items: center;
+  max-width: 520px;
+  padding: 22px 30px;
+  border: 2px solid #ddd;
+  border-radius: 0.5rem;
+  border-radius: 12px;
+}
+
+.l-buttons-container {
+  margin-block-end: 1rem;
+}
+
+.l-buttons-container BUTTON {
+  background: linear-gradient(transparent, #212a3361);
+  border-width: 0;
+}
+
+.l-buttons-container BUTTON:active {
+  background: linear-gradient(#212a3361, transparent);
+}
+
+.l-settings-container {
+  padding-block: 10px;
+  border: 2px solid rgb(35, 35, 53);
+}
+
+.l-settings-container:empty:before {
+  content: "Settings Panel should be rendered here";
+  display: block;
+  padding-inline: 1rem;
+}
+
+.l-settings-container__settings-panel-wrapper {
+  padding: 0.7rem;
+}
+
+
+
+.c-settings-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  min-block-size: 300px;
+  padding: 14px 20px;
+  border: 1px solid rgb(43, 7, 14);
+  border-radius: 0.5rem;
+  box-shadow: 0px 2px 4px hsl(207.89deg 20.23% 10.29% / 32%);
+}

--- a/frontend/src/exercises/ReactSuspenseAndLazyLoading/ReactSuspenseAndLazyLoading.tsx
+++ b/frontend/src/exercises/ReactSuspenseAndLazyLoading/ReactSuspenseAndLazyLoading.tsx
@@ -1,0 +1,42 @@
+import React, { Suspense } from "react";
+import { useState } from "react";
+import "./ReactSuspenseAndLazyLoading.css";
+
+const SettingsPanel = React.lazy(() => {
+  return new Promise((resolve) => {
+    // Artificial delay
+    setTimeout(() => {
+      resolve(import("./SettingsPanel"));
+    }, 3 * 1000);
+  }).then((module) => module as { default: React.FC });
+});
+
+export const ReactSuspenseAndLazyLoading: React.FC = () => {
+  const [showSettings, setShowSettings] = useState<boolean>(false);
+
+  const onShowSettingsClick = () => {
+    setShowSettings((prevState) => !prevState);
+  };
+
+  return (
+    <div className="l-suspense-lazy-loading-container">
+      <h2 className="c-suspense-lazy-loading-title">React Suspense & Lazy Loading</h2>
+      <div className="l-buttons-container">
+        <button onClick={onShowSettingsClick}>
+          {`${showSettings ? `Hide` : `Show`} settings`}
+        </button>
+      </div>
+      <div className="l-settings-container">
+        {showSettings && (
+          <div className="l-settings-container__settings-panel-wrapper">
+            <Suspense fallback={<p>Loading...</p>}>
+              <SettingsPanel />
+            </Suspense>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default ReactSuspenseAndLazyLoading;

--- a/frontend/src/exercises/ReactSuspenseAndLazyLoading/SettingsPanel.tsx
+++ b/frontend/src/exercises/ReactSuspenseAndLazyLoading/SettingsPanel.tsx
@@ -1,0 +1,13 @@
+import React from "react";
+
+export const SettingsPanel: React.FC = React.memo(() => {
+  console.log(`SettingsPanel rendered`);
+  return (
+    <div className="c-settings-panel">
+      <h3>Settings Panel</h3>
+      <p>This panel was lazy loaded!</p>
+    </div>
+  );
+});
+
+export default SettingsPanel;


### PR DESCRIPTION
<requirements>
Learn to:
* Split code with React.lazy
* Show a fallback loader with Suspense
* Understand when components load and render Scenario
You have a dashboard with a heavy settings panel that you don’t want to load until the user clicks a button. You will use React.lazy to dynamically import the panel and wrap it with Suspense so React shows a loading spinner until it is ready.

Create the Lazy Component
Your Tasks
1. Import SettingsPanel using React.lazy.
2. Wrap it with Suspense and add a fallback loader (e.g. <p>Loading...</p>).
3. Make sure the panel loads only when showSettings is true.

Acceptance Criteria
✅ Clicking Show Settings should lazy-load the SettingsPanel file. ✅ While it’s loading, you should see the fallback loader. ✅ Clicking Hide Settings should unmount the panel. ✅ Console should log "SettingsPanel loaded" only once (lazy loading happens on first use). 
</requirements>