### PR TITLE
feat(SearchWithDebouncedAPICalls/SearchWithRequestCaching):

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,5 +1,7 @@
 import "./App.css";
-import DataFetchingWithReactSuspense from "./exercises/DataFetchingWithReactSuspense/DataFetchingWithReactSuspense";
+// import DataFetchingWithReactSuspense from "./exercises/DataFetchingWithReactSuspense/DataFetchingWithReactSuspense";
+// import SearchWithDebouncedAPICalls from "./exercises/SearchWithDebouncedAPICalls/SearchWithDebouncedAPICalls";
+import SearchWithRequestCaching from "./exercises/SearchWithRequestCaching/SearchWithRequestCaching";
 // import PerformanceOptimizationUseMemoUseCallback from "./exercises/PerformanceOptimizationUseMemoUseCallback/PerformanceOptimizationUseMemoUseCallback";
 // import ReactSuspenseAndLazyLoading from "./exercises/ReactSuspenseAndLazyLoading/ReactSuspenseAndLazyLoading";
 // import FormsWithMultipleInputsAndValidation from "./exercises/FormsWithMultipleInputsAndValidation";
@@ -47,8 +49,16 @@ function App() {
         <PerformanceOptimizationUseMemoUseCallback />
       </section> */}
 
-      <section>
+      {/* <section>
         <DataFetchingWithReactSuspense />
+      </section> */}
+
+      {/* <section>
+        <SearchWithDebouncedAPICalls />
+      </section> */}
+
+      <section>
+        <SearchWithRequestCaching />
       </section>
     </main>
   );

--- a/frontend/src/exercises/SearchWithDebouncedAPICalls/SearchWithDebouncedAPICalls.css
+++ b/frontend/src/exercises/SearchWithDebouncedAPICalls/SearchWithDebouncedAPICalls.css
@@ -1,0 +1,20 @@
+.l-search-container {
+    display: grid;
+    place-items: center;
+    max-width: 520px;
+    padding: 22px;
+    border: 2px solid #ddd;
+    border-radius: 0.5rem;
+    border-radius: 12px;
+}
+
+.c-search-input {
+    width: 100%;
+    margin-block-end: 12px;
+    padding: 8px;
+}
+
+.c-loading-message {
+    padding-block: 8px;
+    padding-inline: 4px;
+}

--- a/frontend/src/exercises/SearchWithDebouncedAPICalls/SearchWithDebouncedAPICalls.tsx
+++ b/frontend/src/exercises/SearchWithDebouncedAPICalls/SearchWithDebouncedAPICalls.tsx
@@ -1,0 +1,121 @@
+import { useEffect, useRef, useState } from "react";
+import "./SearchWithDebouncedAPICalls.css";
+import type { Post } from "../../types/Post";
+
+/*
+Practise:
+* Implement debouncing with useEffect + setTimeout
+
+* Fetch results only after the user stops typing
+
+* Handle loading state and show results
+
+* Optimise by memoising callbacks to prevent unnecessary re-renders
+*/
+async function SearchForPosts(searchTerm: string, signal: AbortSignal): Promise<Post[]> {
+  console.log("Fetching search results for:", searchTerm);
+  try {
+    if (signal.aborted) throw new Error("Request has already been aborted");
+
+    const response = await fetch(
+      `https://jsonplaceholder.typicode.com/posts?_limit=5&title=${searchTerm}`,
+      {
+        signal,
+      }
+    );
+
+    if (!response.ok) {
+      const text = await response.text();
+      throw new Error(`Network response was not ok: ${text}`);
+    }
+
+    const data = await response.json();
+
+    return data;
+  } catch (err) {
+    if (err instanceof Error && err.name === "AbortError") {
+      throw new Error("Request aborted");
+    }
+    const newError = new Error(`Something went wrong\n${err}`);
+    console.error(`ERROR FROM SEARCH_WITH_DEBOUNCED_API_CALLS.TSX -> ${newError.message}`);
+    throw newError;
+  }
+}
+
+export const SearchWithDebouncedAPICalls: React.FC = () => {
+  const [query, setQuery] = useState<string>("");
+  const [results, setResults] = useState<Post[]>([]);
+  const [isLoading, setIsLoading] = useState<boolean>(false);
+  const abortControllerRef = useRef<AbortController | null>(null);
+  const debounceTimerID = useRef<number | undefined>(undefined);
+
+  const onInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setQuery(e.target.value);
+  };
+
+  useEffect(() => {
+    if (debounceTimerID.current) {
+      clearTimeout(debounceTimerID.current);
+    }
+
+    if (query.length === 0) {
+      setResults([]);
+      setIsLoading(false);
+      return;
+    }
+
+    debounceTimerID.current = setTimeout(() => {
+      if (abortControllerRef.current) {
+        abortControllerRef.current.abort();
+      }
+
+      abortControllerRef.current = new AbortController();
+
+      setIsLoading(true);
+
+      SearchForPosts(query, abortControllerRef.current.signal)
+        .then((data) => {
+          setResults(data);
+        })
+        .catch((err) => {
+          console.error(err);
+        })
+        .finally(() => {
+          setIsLoading(false);
+        });
+    }, 500);
+
+    return () => {
+      abortControllerRef.current?.abort();
+      clearTimeout(debounceTimerID.current);
+    };
+  }, [query]);
+
+  return (
+    <div className="l-search-container">
+      <h2 className="c-search-title">Search With Debounced API Calls</h2>
+      <div>
+        <input type="text" value={query} onChange={onInputChange} className="c-search-input" />
+      </div>
+      {isLoading && <p className="c-loading-message">Loading posts...</p>}
+      {!isLoading && results.length === 0 && query.length > 0 && (
+        <p className="c-no-results-message">No results found</p>
+      )}
+      {!isLoading && results.length > 0 && (
+        <ul>
+          {results.map((post) => {
+            return (
+              <li key={post.id}>
+                <p>{`User ID: ${post.userId}`}</p>
+                <p>{`title: ${post.title}`}</p>
+                <p>{`body: ${post.body}`}</p>
+              </li>
+            );
+          })}
+        </ul>
+      )}
+    </div>
+  );
+};
+
+export default SearchWithDebouncedAPICalls;

--- a/frontend/src/exercises/SearchWithRequestCaching/SearchWithRequestCaching.css
+++ b/frontend/src/exercises/SearchWithRequestCaching/SearchWithRequestCaching.css
@@ -1,0 +1,20 @@
+.l-search-container {
+    display: grid;
+    place-items: center;
+    max-width: 520px;
+    padding: 22px;
+    border: 2px solid #ddd;
+    border-radius: 0.5rem;
+    border-radius: 12px;
+}
+
+.c-search-input {
+    width: 100%;
+    margin-block-end: 12px;
+    padding: 8px;
+}
+
+.c-loading-message {
+    padding-block: 8px;
+    padding-inline: 4px;
+}

--- a/frontend/src/exercises/SearchWithRequestCaching/SearchWithRequestCaching.tsx
+++ b/frontend/src/exercises/SearchWithRequestCaching/SearchWithRequestCaching.tsx
@@ -1,0 +1,128 @@
+import { useEffect, useRef, useState } from "react";
+import "./SearchWithRequestCaching.css";
+import type { Post } from "../../types/Post";
+
+/*
+Practise:
+* Store previous search results in a cache (object or Map)
+
+* Reuse cached data instead of re-fetching from the API
+
+* Avoid unnecessary loading states when cached data exists
+*/
+async function SearchForPosts(searchTerm: string, signal: AbortSignal): Promise<Post[]> {
+  console.log("Fetching search results for:", searchTerm);
+  try {
+    if (signal.aborted) throw new Error("Request has already been aborted");
+
+    const response = await fetch(
+      `https://jsonplaceholder.typicode.com/posts?_limit=5&title=${searchTerm}`,
+      {
+        signal,
+      }
+    );
+
+    if (!response.ok) {
+      const text = await response.text();
+      throw new Error(`Network response was not ok: ${text}`);
+    }
+
+    const data = await response.json();
+
+    return data;
+  } catch (err) {
+    if (err instanceof Error && err.name === "AbortError") {
+      throw new Error("Request aborted");
+    }
+    const newError = new Error(`Something went wrong\n${err}`);
+    console.error(`ERROR FROM SEARCH_WITH_DEBOUNCED_API_CALLS.TSX -> ${newError.message}`);
+    throw newError;
+  }
+}
+
+export const SearchWithRequestCaching: React.FC = () => {
+  const [query, setQuery] = useState<string>("");
+  const [results, setResults] = useState<Post[]>([]);
+  const [isLoading, setIsLoading] = useState<boolean>(false);
+  const abortControllerRef = useRef<AbortController | null>(null);
+  const debounceTimerID = useRef<number | undefined>(undefined);
+  const cache = useRef<Record<string, Post[]>>({});
+
+  const onInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setQuery(e.target.value);
+  };
+
+  useEffect(() => {
+    if (debounceTimerID.current) {
+      clearTimeout(debounceTimerID.current);
+    }
+
+    if (query.length === 0) {
+      setResults([]);
+      setIsLoading(false);
+      return;
+    }
+
+    const normalizedQuery = query.trim().toLowerCase();
+
+    if (cache.current[normalizedQuery]) {
+      setResults(cache.current[normalizedQuery]);
+      return;
+    }
+
+    debounceTimerID.current = setTimeout(() => {
+      if (abortControllerRef.current) {
+        abortControllerRef.current.abort();
+      }
+
+      abortControllerRef.current = new AbortController();
+
+      setIsLoading(true);
+
+      SearchForPosts(normalizedQuery, abortControllerRef.current.signal)
+        .then((data) => {
+          setResults(data);
+          cache.current[normalizedQuery] = data;
+        })
+        .catch((err) => {
+          console.error(err);
+        })
+        .finally(() => {
+          setIsLoading(false);
+        });
+    }, 500);
+
+    return () => {
+      abortControllerRef.current?.abort();
+      clearTimeout(debounceTimerID.current);
+    };
+  }, [query]);
+
+  return (
+    <div className="l-search-container">
+      <h2 className="c-search-title">Search With Debounced API Calls</h2>
+      <div>
+        <input type="text" value={query} onChange={onInputChange} className="c-search-input" />
+      </div>
+      {isLoading && <p className="c-loading-message">Loading posts...</p>}
+      {!isLoading && results.length === 0 && query.length > 0 && (
+        <p className="c-no-results-message">No results found</p>
+      )}
+      {!isLoading && results.length > 0 && (
+        <ul>
+          {results.map((post) => {
+            return (
+              <li key={post.id}>
+                <p>{`User ID: ${post.userId}`}</p>
+                <p>{`title: ${post.title}`}</p>
+                <p>{`body: ${post.body}`}</p>
+              </li>
+            );
+          })}
+        </ul>
+      )}
+    </div>
+  );
+};
+
+export default SearchWithRequestCaching;


### PR DESCRIPTION
**Search with Debounced API Calls**

**Goal**
Learn to:
* Implement debouncing with `useEffect` + `setTimeout`
* Fetch results only after the user stops typing
* Handle loading state and show results
* Optimise by memoising callbacks to prevent unnecessary re-renders

**Scenario**
You are building a search feature where typing in the input box queries a server. You must avoid firing a request on every keystroke and only call the API when the user stops typing for 500ms.

**Your Tasks**
1. Implement `useEffect` to:
   * Cancel any pending timeout on cleanup
   * Trigger `searchItems(query)` only if query is non-empty
   * Update `loading` before/after the fetch
   * Handle race conditions (ignore stale results if user typed again before fetch finished)
2. Ensure that clearing the input (`query === ""`) immediately clears results and stops loading.
3. Confirm that `console.log` in `searchItems` only runs when user pauses typing for 500ms.

**Acceptance Criteria**
* Results update after 500ms of no typing
* Previous requests are cancelled (or ignored) if user keeps typing
* Loading indicator shows while fetching
* Clearing input immediately clears results and hides loading state </requirements>

---

**Search with Request Caching**

**Goal**
Learn to:
* Store previous search results in a cache (object or Map)
* Reuse cached data instead of re-fetching from the API
* Avoid unnecessary loading states when cached data exists

**Scenario**
Your search feature (from the previous assignment) is working, but it fetches data every time the user types, even if they previously searched for the same query. You want to store previous results in memory and reuse them instantly on repeat searches.

**Your Tasks**
1. Implement the `cache` using `useRef`.
2. Check cache before fetching and immediately set results if available.
3. Store new results in cache after fetching.
4. Confirm that:
   * First search fetches from API (see `console.log`).
   * Second search with the same query **does not fetch again**.
   * Clearing input and retyping a cached query instantly shows results without loading. **Acceptance Criteria**
* Cached results are reused
* Loading indicator only shows on first search
* ``console.log`` from `SearchForPosts` does **not** run when cached data is used