### PR TITLE
Users/konrud/error boundaries global and async error handling

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,5 +1,6 @@
 import "./App.css";
-import ErrorBoundariesGlobalErrorHandling from "./exercises/ErrorBoundariesGlobalErrorHandling/ErrorBoundariesGlobalErrorHandling";
+import ErrorBoundariesGlobalAndAsyncErrorHandling from "./exercises/ErrorBoundariesGlobalAndAsyncErrorHandling/ErrorBoundariesGlobalAndAsyncErrorHandling";
+// import ErrorBoundariesGlobalErrorHandling from "./exercises/ErrorBoundariesGlobalErrorHandling/ErrorBoundariesGlobalErrorHandling";
 // import HandlingErrorsInAsyncReactCode from "./exercises/HandlingErrorsInAsyncReactCode/HandlingErrorsInAsyncReactCode";
 // import DataFetchingWithReactSuspense from "./exercises/DataFetchingWithReactSuspense/DataFetchingWithReactSuspense";
 // import SearchWithDebouncedAPICalls from "./exercises/SearchWithDebouncedAPICalls/SearchWithDebouncedAPICalls";
@@ -63,8 +64,12 @@ function App() {
         <HandlingErrorsInAsyncReactCode />
       </section> */}
 
-      <section>
+      {/* <section>
         <ErrorBoundariesGlobalErrorHandling />
+      </section> */}
+
+      <section>
+        <ErrorBoundariesGlobalAndAsyncErrorHandling />
       </section>
     </main>
   );

--- a/frontend/src/exercises/ErrorBoundariesGlobalAndAsyncErrorHandling/BuggyAsyncComponent.tsx
+++ b/frontend/src/exercises/ErrorBoundariesGlobalAndAsyncErrorHandling/BuggyAsyncComponent.tsx
@@ -1,0 +1,31 @@
+import { useEffect } from "react";
+import useGlobalError from "./hooks/useGlobalError";
+import { GLOBAL_ERROR } from "./IGlobalError";
+
+export const BuggyAsyncComponent: React.FC = () => {
+  const { setError } = useGlobalError();
+
+  useEffect(() => {
+    const timerID = setTimeout(() => {
+      setError({
+        id: "1",
+        timestamp: new Date(),
+        type: GLOBAL_ERROR.NETWORK,
+        message: "BuggyAsyncComponent: => Failed to fetch data from server",
+      });
+    }, 1.5 * 1000);
+
+    return () => {
+      clearTimeout(timerID);
+    };
+  }, [setError]);
+
+  return (
+    <div style={{ border: "2px solid", borderRadius: "3px", padding: "10px 20px" }}>
+      <h2>Buggy Async Component</h2>
+      <p>Loading Async data...</p>
+    </div>
+  );
+};
+
+export default BuggyAsyncComponent;

--- a/frontend/src/exercises/ErrorBoundariesGlobalAndAsyncErrorHandling/BuggyComponent.tsx
+++ b/frontend/src/exercises/ErrorBoundariesGlobalAndAsyncErrorHandling/BuggyComponent.tsx
@@ -1,0 +1,34 @@
+import { useState } from "react";
+
+export const BuggyComponent = () => {
+  const [counter, setCounter] = useState(0);
+
+  if (counter === 3) {
+    throw new Error("I crashed!");
+  }
+
+  return (
+    <div
+      style={{
+        display: "flex",
+        flexDirection: "column",
+        gap: "15px",
+        border: "1px solid black",
+        padding: "10px",
+        margin: "10px",
+      }}
+    >
+      <p>Counter: {counter}</p>
+      <hr />
+      <p>
+        Click the button to increase the counter.When the counter reaches 3, the component will
+        throw an error.This simulates a component that crashes during rendering.
+      </p>
+      <button onClick={() => setCounter((prevCounter) => prevCounter + 1)}>
+        Increment Counter
+      </button>
+    </div>
+  );
+};
+
+export default BuggyComponent;

--- a/frontend/src/exercises/ErrorBoundariesGlobalAndAsyncErrorHandling/ErrorBoundariesGlobalAndAsyncErrorHandling.css
+++ b/frontend/src/exercises/ErrorBoundariesGlobalAndAsyncErrorHandling/ErrorBoundariesGlobalAndAsyncErrorHandling.css
@@ -1,0 +1,9 @@
+.l-error-boundary-container {
+    display: grid;
+    place-items: center;
+    max-width: 520px;
+    padding: 22px;
+    border: 2px solid #ddd;
+    border-radius: 0.5rem;
+    border-radius: 12px;
+}

--- a/frontend/src/exercises/ErrorBoundariesGlobalAndAsyncErrorHandling/ErrorBoundariesGlobalAndAsyncErrorHandling.tsx
+++ b/frontend/src/exercises/ErrorBoundariesGlobalAndAsyncErrorHandling/ErrorBoundariesGlobalAndAsyncErrorHandling.tsx
@@ -1,0 +1,38 @@
+import "./ErrorBoundariesGlobalAndAsyncErrorHandling.css";
+import { ErrorBoundary } from "./ErrorBoundary";
+import BuggyComponent from "./BuggyComponent";
+import BuggyAsyncComponent from "./BuggyAsyncComponent";
+import GlobalErrorOverlay from "./GlobalErrorOverlay";
+import GlobalErrorProvider from "./GlobalErrorProvider";
+
+/*
+Practise:
+* Catch both UI render errors and async/network errors in a unified way
+
+* Show a global fallback UI for critical errors
+
+* Provide a recovery mechanism (reset, retry, or reload)
+*/
+
+export const ErrorBoundariesGlobalAndAsyncErrorHandling: React.FC = () => {
+  return (
+    <GlobalErrorProvider>
+      <ErrorBoundary>
+        <div className="l-error-boundary-container">
+          <h2 className="c-error-boundary-title">
+            Global Error Handling with Error Boundaries + Async Errors
+          </h2>
+          <div>
+            <BuggyComponent />
+          </div>
+          <div>
+            <BuggyAsyncComponent />
+          </div>
+          <GlobalErrorOverlay />
+        </div>
+      </ErrorBoundary>
+    </GlobalErrorProvider>
+  );
+};
+
+export default ErrorBoundariesGlobalAndAsyncErrorHandling;

--- a/frontend/src/exercises/ErrorBoundariesGlobalAndAsyncErrorHandling/ErrorBoundary.tsx
+++ b/frontend/src/exercises/ErrorBoundariesGlobalAndAsyncErrorHandling/ErrorBoundary.tsx
@@ -1,0 +1,70 @@
+import React, { Component, type ErrorInfo, type ReactNode } from "react";
+
+type ErrorBoundaryProps = {
+  children: ReactNode;
+};
+
+type ErrorBoundaryState = {
+  hasError: boolean;
+};
+
+export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
+  constructor(props: ErrorBoundaryProps) {
+    super(props);
+    this.state = { hasError: false };
+
+    this.handleReset = this.handleReset.bind(this);
+  }
+
+  static getDerivedStateFromError() {
+    return { hasError: true };
+  }
+
+  componentDidCatch(error: Error, info: ErrorInfo) {
+    console.error("ErrorBoundary caught an error", error, info);
+    // Here we can also log the error to an external service
+
+    // Enhanced error context for monitoring services
+    const errorContext = {
+      error: error.message,
+      stack: error.stack,
+      componentStack: info.componentStack,
+      timestamp: new Date().toISOString(),
+      userAgent: navigator.userAgent,
+      url: window.location.href,
+    };
+
+    console.log(`\n===============\n`);
+    console.log(errorContext);
+    console.log(`\n===============\n`);
+
+    // Integration point for error monitoring (Sentry, DataDog, etc.)
+    // ErrorMonitoringService.captureError(errorContext);
+  }
+
+  handleReset = () => {
+    this.setState({ hasError: false });
+  };
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        <div
+          style={{
+            padding: "20px",
+            border: "2px solid crimson",
+            borderRadius: "5px",
+            backgroundColor: "#ffe6e6",
+          }}
+        >
+          <h2>Something went terribly wrong (UI crash).</h2>
+          <div>
+            <button onClick={this.handleReset}>Try again</button>
+          </div>
+        </div>
+      );
+    }
+
+    return this.props.children;
+  }
+}

--- a/frontend/src/exercises/ErrorBoundariesGlobalAndAsyncErrorHandling/GlobalErrorContext.tsx
+++ b/frontend/src/exercises/ErrorBoundariesGlobalAndAsyncErrorHandling/GlobalErrorContext.tsx
@@ -1,0 +1,21 @@
+import { createContext } from "react";
+import type { IGlobalError } from "./IGlobalError";
+
+export type GlobalErrorContextType = {
+  error: IGlobalError | null;
+  setError: (err: IGlobalError | null) => void;
+};
+
+// Could be enhanced with
+/*
+    interface GlobalErrorContextType {
+        errors: GlobalError[];
+        addError: (error: Omit<GlobalError, 'id' | 'timestamp'>) => void;
+        removeError: (id: string) => void;
+        clearAllErrors: () => void;
+    }
+*/
+
+const GlobalErrorContext = createContext<GlobalErrorContextType | undefined>(undefined);
+
+export default GlobalErrorContext;

--- a/frontend/src/exercises/ErrorBoundariesGlobalAndAsyncErrorHandling/GlobalErrorOverlay.css
+++ b/frontend/src/exercises/ErrorBoundariesGlobalAndAsyncErrorHandling/GlobalErrorOverlay.css
@@ -1,0 +1,20 @@
+.c-global-error {
+    position: fixed;
+    inset: 0;
+    inset-block-end: auto;
+    padding: 20px;
+    text-align: center;
+    background: rgba(126, 13, 13, 0.9);
+    color: rgb(252, 252, 252);
+}
+
+.c-global-error__btn {
+    margin-top: 20px;
+    padding: 10px 20px;
+    font-size: 16px;
+    background-color: #f4f4f4;
+    color: #260c0c;
+    border: none;
+    border-radius: 5px;
+    cursor: pointer;
+}

--- a/frontend/src/exercises/ErrorBoundariesGlobalAndAsyncErrorHandling/GlobalErrorOverlay.tsx
+++ b/frontend/src/exercises/ErrorBoundariesGlobalAndAsyncErrorHandling/GlobalErrorOverlay.tsx
@@ -1,0 +1,26 @@
+import useGlobalError from "./hooks/useGlobalError";
+import "./GlobalErrorOverlay.css";
+
+export const GlobalErrorOverlay = () => {
+  const { error, setError } = useGlobalError();
+
+  if (!error) {
+    return null;
+  }
+
+  const handleDismiss = () => {
+    setError(null);
+  };
+
+  return (
+    <div className="c-global-error">
+      <h2>Global Error</h2>
+      <p>{error.message}</p>
+      <button onClick={handleDismiss} type="button" className="c-global-error__btn">
+        Dismiss
+      </button>
+    </div>
+  );
+};
+
+export default GlobalErrorOverlay;

--- a/frontend/src/exercises/ErrorBoundariesGlobalAndAsyncErrorHandling/GlobalErrorProvider.tsx
+++ b/frontend/src/exercises/ErrorBoundariesGlobalAndAsyncErrorHandling/GlobalErrorProvider.tsx
@@ -1,0 +1,15 @@
+import { useState, type ReactNode } from "react";
+import GlobalErrorContext from "./GlobalErrorContext";
+import type { IGlobalError } from "./IGlobalError";
+
+export const GlobalErrorProvider: React.FC<{ children: ReactNode }> = ({ children }) => {
+  const [error, setError] = useState<IGlobalError | null>(null);
+
+  return (
+    <GlobalErrorContext.Provider value={{ error, setError }}>
+      {children}
+    </GlobalErrorContext.Provider>
+  );
+};
+
+export default GlobalErrorProvider;

--- a/frontend/src/exercises/ErrorBoundariesGlobalAndAsyncErrorHandling/IGlobalError.ts
+++ b/frontend/src/exercises/ErrorBoundariesGlobalAndAsyncErrorHandling/IGlobalError.ts
@@ -1,0 +1,13 @@
+export interface IGlobalError {
+  id: string;
+  message: string;
+  type: (typeof GLOBAL_ERROR)[keyof typeof GLOBAL_ERROR];
+  timestamp: Date;
+  context?: Record<string, unknown>;
+}
+
+export const GLOBAL_ERROR = {
+  NETWORK: "network",
+  VALIDATION: "validation",
+  UNKNOWN: "unknown",
+};

--- a/frontend/src/exercises/ErrorBoundariesGlobalAndAsyncErrorHandling/hooks/useGlobalError.ts
+++ b/frontend/src/exercises/ErrorBoundariesGlobalAndAsyncErrorHandling/hooks/useGlobalError.ts
@@ -1,0 +1,14 @@
+import { useContext } from "react";
+import GlobalErrorContext from "../GlobalErrorContext";
+
+export const useGlobalError = () => {
+  const errorContext = useContext(GlobalErrorContext);
+
+  if (!errorContext) {
+    throw new Error("useGlobalError must be used inside GlobalErrorProvider");
+  }
+
+  return errorContext;
+};
+
+export default useGlobalError;


### PR DESCRIPTION
feat(ErrorBoundariesGlobalAndAsyncErrorHandling):

Goal
Learn to:
* Catch both UI render errors and async/network errors in a unified way
* Show a global fallback UI for critical errors
* Provide a recovery mechanism (reset, retry, or reload)

Scenario
We want one global error handler that:
1. Wraps the app with an ErrorBoundary for render-time crashes.
2. Provides a global error context for async/network errors.
3. Shows a global error overlay when something goes wrong.

Your Tasks
1. Implement ErrorProvider + useGlobalError hook.
2. Update BuggyAsyncComponent to report async errors via global context.
3. Add GlobalErrorOverlay to display async errors.
4. Confirm that:
   * UI crash (BuggyComponent throwing on count === 3) is caught by ErrorBoundary.
   * Async failure (BuggyAsyncComponent) shows a dismissible red overlay.
   * Both types of errors are handled separately, without crashing the app.

Acceptance Criteria
* UI crashes show fallback from ErrorBoundary
* Async errors show a global overlay
* User can dismiss async errors
* App continues running after errors